### PR TITLE
Fix strict standards error from calling reset() without a variable

### DIFF
--- a/src/Engine/Ast/Root.php
+++ b/src/Engine/Ast/Root.php
@@ -14,7 +14,7 @@ class Root extends UnlimitedChildrenParentNode
      */
     public function getFirstChild()
     {
-        $child = reset($this->getChildren());
+        $child = current($this->getChildren());
 
         if (!($child instanceof Node)) {
             throw new OutOfBoundsException('Cannot get first child Root node does not contain any children.');


### PR DESCRIPTION
`reset()` caused a strict standards error due to passing a non-variable by reference. Although `current()` also expects a reference, it works without raising any errors.

In the case of an array being returned from a function call, `current()` and `reset()` are equivalent as the array pointer will always be at the first element.